### PR TITLE
Drop $ignoreOutput parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,6 @@ $detector = new SideEffectsDetector();
 var_dump($detector->getSideEffects($code)); // [SideEffect::STANDARD_OUTPUT]
 ```
 
-In case you want treat output not to be a side-effect:
-
-```php
-use staabm\SideEffectsDetector\SideEffectsDetector;
-
-$code = '<?php version_compare(PHP_VERSION, "8.0", ">=") or echo("skip because attributes are only available since PHP 8.0");';
-
-$detector = new SideEffectsDetector();
-var_dump($detector->getSideEffects($code, $ignoreOutput=true)); // []
-```
-
 In case functions are called which are not known to have side-effects - e.g. userland functions - `null` is returned.
 
 ```php
@@ -38,7 +27,7 @@ use staabm\SideEffectsDetector\SideEffectsDetector;
 $code = '<?php userlandFunction();';
 
 $detector = new SideEffectsDetector();
-var_dump($detector->getSideEffects($code, $ignoreOutput=false)); // [SideEffect::MAYBE]
+var_dump($detector->getSideEffects($code)); // [SideEffect::MAYBE]
 ```
 
 Code might have multiple side-effects:
@@ -46,10 +35,10 @@ Code might have multiple side-effects:
 ```php
 use staabm\SideEffectsDetector\SideEffectsDetector;
 
-$code = '<?php userlandFunction();';
+$code = '<?php include "some-file.php"; echo "hello world"; exit(1);';
 
 $detector = new SideEffectsDetector();
-var_dump($detector->getSideEffects($code, $ignoreOutput=false)); // [SideEffect::SCOPE_POLLUTION, SideEffect::STANDARD_OUTPUT, SideEffect::PROCESS_EXIT]
+var_dump($detector->getSideEffects($code)); // [SideEffect::SCOPE_POLLUTION, SideEffect::STANDARD_OUTPUT, SideEffect::PROCESS_EXIT]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Analyzes php-code for side-effects.
 
 When code has no side-effects it can e.g. be used with `eval($code)` in the same process without interfering.
+[Side-effects are classified](https://github.com/staabm/side-effects-detector/blob/main/lib/SideEffect.php) into categories to filter them more easily depending on your use-case.
 
 ## Install
 

--- a/lib/SideEffectsDetector.php
+++ b/lib/SideEffectsDetector.php
@@ -67,11 +67,9 @@ final class SideEffectsDetector {
     /**
      * @api
      *
-     * @param bool $ignoreOutput Whether to ignore output functions like echo, print, etc.
-     *
      * @return array<SideEffect::*>
      */
-    public function getSideEffects(string $code, bool $ignoreOutput = false): array {
+    public function getSideEffects(string $code): array {
         $tokens = token_get_all($code);
 
         $sideEffects = [];
@@ -87,7 +85,7 @@ final class SideEffectsDetector {
                 continue;
             }
 
-            if (!$ignoreOutput && in_array($token[0], self::OUTPUT_TOKENS, true)) {
+            if (in_array($token[0], self::OUTPUT_TOKENS, true)) {
                 $sideEffects[] = SideEffect::STANDARD_OUTPUT;
                 continue;
             }

--- a/tests/SideEffectsDetectorTest.php
+++ b/tests/SideEffectsDetectorTest.php
@@ -11,71 +11,68 @@ class SideEffectsDetectorTest extends TestCase {
     /**
      * @dataProvider dataHasSideEffects
      */
-    public function testHasSideEffects(string $code, array $expected, array $expectedIgnoreOutput): void {
+    public function testHasSideEffects(string $code, array $expected): void {
         $detector = new SideEffectsDetector();
         self::assertSame($expected, $detector->getSideEffects($code));
-
-        self::assertSame($expectedIgnoreOutput, $detector->getSideEffects($code, true));
     }
 
     static public function dataHasSideEffects():iterable
     {
-        yield ['<?php function abc() {}', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php function abc() {}', [SideEffect::SCOPE_POLLUTION]];
 
         if (PHP_VERSION_ID < 80000) {
             // PHP7.x misses accurate reflection information
-            yield ['<?php gc_enable();', [SideEffect::MAYBE], [SideEffect::MAYBE]];
-            yield ['<?php gc_enabled();', [], []];
-            yield ['<?php gc_disable();', [SideEffect::MAYBE], [SideEffect::MAYBE]];
+            yield ['<?php gc_enable();', [SideEffect::MAYBE]];
+            yield ['<?php gc_enabled();', []];
+            yield ['<?php gc_disable();', [SideEffect::MAYBE]];
         } else {
-            yield ['<?php gc_enable();', [SideEffect::UNKNOWN_CLASS], [SideEffect::UNKNOWN_CLASS]];
-            yield ['<?php gc_enabled();', [], []];
-            yield ['<?php gc_disable();', [SideEffect::UNKNOWN_CLASS], [SideEffect::UNKNOWN_CLASS]];
+            yield ['<?php gc_enable();', [SideEffect::UNKNOWN_CLASS]];
+            yield ['<?php gc_enabled();', []];
+            yield ['<?php gc_disable();', [SideEffect::UNKNOWN_CLASS]];
         }
-        yield ['<?php $_GET["A"] = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $_POST["A"] = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $_COOKIE["A"] = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $_REQUEST["A"] = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $this->x = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php MyClass::$x = 1;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $this->doFoo();', [SideEffect::MAYBE], [SideEffect::MAYBE]];
-        yield ['<?php MyClass::doFooBar();', [SideEffect::MAYBE], [SideEffect::MAYBE]];
-        yield ['<?php putenv("MY_X=1");', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $x = getenv("MY_X");', [], []];
-        yield ['<?php ini_set("memory_limit", "1024M");', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php $x = ini_get("memory_limit");', [], []];
-        yield ['<?php echo "Hello World";', [SideEffect::STANDARD_OUTPUT], []];
-        yield ['<?php print("Hello World");', [SideEffect::STANDARD_OUTPUT], []];
-        yield ['<?php fopen("file.txt");', [SideEffect::INPUT_OUTPUT], [SideEffect::INPUT_OUTPUT]];
-        yield ['<?php version_compare(PHP_VERSION, "8.0", ">=") or die("skip because attributes are only available since PHP 8.0");', [SideEffect::PROCESS_EXIT], [SideEffect::PROCESS_EXIT]];
-        yield ['<?php version_compare(PHP_VERSION, "8.0", ">=") or echo("skip because attributes are only available since PHP 8.0");', [SideEffect::STANDARD_OUTPUT], []];
-        yield ['<?php die(0);', [SideEffect::PROCESS_EXIT], [SideEffect::PROCESS_EXIT]];
-        yield ['<?php exit(0);', [SideEffect::PROCESS_EXIT], [SideEffect::PROCESS_EXIT]];
-        yield ['<?php eval($x);', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php global $x; $x = [];', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php goto somewhere;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php include "some-file.php";', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php include_once "some-file.php";', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php require "some-file.php";', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php require_once "some-file.php";', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $_GET["A"] = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $_POST["A"] = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $_COOKIE["A"] = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $_REQUEST["A"] = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $this->x = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php MyClass::$x = 1;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $this->doFoo();', [SideEffect::MAYBE]];
+        yield ['<?php MyClass::doFooBar();', [SideEffect::MAYBE]];
+        yield ['<?php putenv("MY_X=1");', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $x = getenv("MY_X");', []];
+        yield ['<?php ini_set("memory_limit", "1024M");', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php $x = ini_get("memory_limit");', []];
+        yield ['<?php echo "Hello World";', [SideEffect::STANDARD_OUTPUT]];
+        yield ['<?php print("Hello World");', [SideEffect::STANDARD_OUTPUT]];
+        yield ['<?php fopen("file.txt");', [SideEffect::INPUT_OUTPUT]];
+        yield ['<?php version_compare(PHP_VERSION, "8.0", ">=") or die("skip because attributes are only available since PHP 8.0");', [SideEffect::PROCESS_EXIT]];
+        yield ['<?php version_compare(PHP_VERSION, "8.0", ">=") or echo("skip because attributes are only available since PHP 8.0");', [SideEffect::STANDARD_OUTPUT]];
+        yield ['<?php die(0);', [SideEffect::PROCESS_EXIT]];
+        yield ['<?php exit(0);', [SideEffect::PROCESS_EXIT]];
+        yield ['<?php eval($x);', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php global $x; $x = [];', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php goto somewhere;', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php include "some-file.php";', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php include_once "some-file.php";', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php require "some-file.php";', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php require_once "some-file.php";', [SideEffect::SCOPE_POLLUTION]];
         // constructor might have side-effects
-        yield ['<?php throw new RuntimeException("foo");', [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE], [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE]];
-        yield ['<?php unknownFunction($x);', [SideEffect::MAYBE], [SideEffect::MAYBE]];
-        yield ['<?php echo unknownFunction($x);', [SideEffect::STANDARD_OUTPUT, SideEffect::MAYBE], [SideEffect::MAYBE]];
-        yield ['<?php unset($x);', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php (unset)$x;', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php throw new RuntimeException("foo");', [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE]];
+        yield ['<?php unknownFunction($x);', [SideEffect::MAYBE]];
+        yield ['<?php echo unknownFunction($x);', [SideEffect::STANDARD_OUTPUT, SideEffect::MAYBE]];
+        yield ['<?php unset($x);', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php (unset)$x;', [SideEffect::SCOPE_POLLUTION]];
         // constructor might have side-effects
-        yield ['<?php new SomeClass();', [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE], [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE]];
-        yield ['<?php function abc() {}', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php class abc {}', [SideEffect::SCOPE_POLLUTION], [SideEffect::SCOPE_POLLUTION]];
-        yield ['<?php (function (){})();', [], []];
-        yield ['<?php (function(){})();', [], []];
-        yield ['<?php (function(){echo "hi";})();', [SideEffect::STANDARD_OUTPUT], []];
-        yield ['<?php (function (){echo "hi";})();', [SideEffect::STANDARD_OUTPUT], []];
+        yield ['<?php new SomeClass();', [SideEffect::SCOPE_POLLUTION, SideEffect::MAYBE]];
+        yield ['<?php function abc() {}', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php class abc {}', [SideEffect::SCOPE_POLLUTION]];
+        yield ['<?php (function (){})();', []];
+        yield ['<?php (function(){})();', []];
+        yield ['<?php (function(){echo "hi";})();', [SideEffect::STANDARD_OUTPUT]];
+        yield ['<?php (function (){echo "hi";})();', [SideEffect::STANDARD_OUTPUT]];
 
         yield ['<?php include "some-file.php"; echo "hello world"; exit(1);',
             [SideEffect::SCOPE_POLLUTION, SideEffect::STANDARD_OUTPUT, SideEffect::PROCESS_EXIT],
-            [SideEffect::SCOPE_POLLUTION, SideEffect::PROCESS_EXIT],
         ];
     }
 }


### PR DESCRIPTION
Ignoring output no longer makes sense, since we just return an array and the caller can easiy ignore whatever fits the use-case